### PR TITLE
Several improvements and added STX viewer

### DIFF
--- a/FlashbackLight/Formats/SPC.cs
+++ b/FlashbackLight/Formats/SPC.cs
@@ -11,14 +11,14 @@ namespace FlashbackLight.Formats
     {
         public byte[] Unk1;
         public uint Unk2;
-        public List<SPCEntry> Entries;
+        public Dictionary<string, SPCEntry> Entries;
 
 
         public SPC()
         {
             Unk1 = new byte[0x24];
             Unk2 = 4;
-            Entries = new List<SPCEntry>();
+            Entries = new Dictionary<string, SPCEntry>();
         }
 
         public SPC(byte[] bytes, string spcName)
@@ -47,7 +47,7 @@ namespace FlashbackLight.Formats
             }
             reader.BaseStream.Seek(0x0C, SeekOrigin.Current);
 
-            Entries = new List<SPCEntry>();
+            Entries = new Dictionary<string, SPCEntry>();
             for (int i = 0; i < fileCount; i++)
             {
                 SPCEntry entry = new SPCEntry();
@@ -72,7 +72,7 @@ namespace FlashbackLight.Formats
                 entry.Contents = data;
                 reader.BaseStream.Seek(dataPadding, SeekOrigin.Current);
 
-                Entries.Add(entry);
+                Entries[entry.Filename] = entry;
             }
         }
 

--- a/FlashbackLight/Formats/WRD.cs
+++ b/FlashbackLight/Formats/WRD.cs
@@ -94,6 +94,13 @@ namespace FlashbackLight.Formats
                     // If the first filename fails, we probably need to remove a duplicate
                     // region tag from the filename before "_text_".
                     textSPCName = textSPCName.Remove(textSPCName.LastIndexOf("_text_") - 3, 3);
+
+                    if (!File.Exists(textSPCName))
+                    {
+                        // If the file still doesn't exist, it's probably not
+                        // there and the strings should just be abandoned.
+                        return;
+                    }
                 }
 
                 string stxName = wrdName.Replace(".wrd", ".stx");

--- a/FlashbackLight/Formats/WRD.cs
+++ b/FlashbackLight/Formats/WRD.cs
@@ -84,73 +84,84 @@ namespace FlashbackLight.Formats
 
             // Read dialogue text strings
             Strings = new List<string>();
-            if (externalStrings)
+            if (stringCount > 0)
             {
-                // Strings are stored in the "(current spc name)_text_(region).spc" file,
-                // within an STX file with the same name as the current WRD file.
-                string textSPCName = textSPCName = spcName.Insert(spcName.LastIndexOf('.'), string.Format("_text_{0}", MainForm.RegionString));
-                if (!File.Exists(textSPCName))
-                {
-                    // If the first filename fails, we probably need to remove a duplicate
-                    // region tag from the filename before "_text_".
-                    textSPCName = textSPCName.Remove(textSPCName.LastIndexOf("_text_") - 3, 3);
+                // If we already know that there are no strings,
+                // there's no need to go through the work to find them.
 
+                if (externalStrings)
+                {
+                    // Strings are stored in the "(current spc name)_text_(region).spc" file,
+                    // within an STX file with the same name as the current WRD file.
+                    string textSPCName = textSPCName = spcName.Insert(spcName.LastIndexOf('.'), string.Format("_text_{0}", MainForm.RegionString));
                     if (!File.Exists(textSPCName))
                     {
-                        // If the file still doesn't exist, it's probably not
-                        // there and the strings should just be abandoned.
-                        return;
-                    }
-                }
+                        // If the first filename fails, we probably need to remove a duplicate
+                        // region tag from the filename before "_text_".
+                        textSPCName = textSPCName.Remove(textSPCName.LastIndexOf("_text_") - 3, 3);
 
-                string stxName = wrdName.Replace(".wrd", ".stx");
-                byte[] spcData = File.ReadAllBytes(textSPCName);
-                SPC textSPC = new SPC(spcData, textSPCName);
-                foreach (SPCEntry entry in textSPC.Entries)
-                {
-                    if (entry.Filename == stxName)
-                    {
-                        Strings = (new STX(entry.Contents)).Strings;
-                        break;
+                        if (!File.Exists(textSPCName))
+                        {
+                            // If the file still doesn't exist, it's probably not
+                            // there and the strings should just be abandoned.
+                            System.Windows.Forms.MessageBox.Show($"{spcName} does not have an associated .stx text file.",
+                                "Missing .stx file",
+                                System.Windows.Forms.MessageBoxButtons.OK,
+                                System.Windows.Forms.MessageBoxIcon.Warning,
+                                System.Windows.Forms.MessageBoxDefaultButton.Button1);
+                            return;
+                        }
                     }
-                }
-            }
-            else
-            {
-                reader.BaseStream.Seek(stringsPointer, SeekOrigin.Begin);
-                for (ushort i = 0; i < stringCount; ++i)
-                {
-                    short stringLen = 0;
 
-                    // The string length is a signed byte, so if it's larger than 0x7F,
-                    // that means the length is actually stored in a signed short,
-                    // since we can't have a negative string length.
-                    // ┐(´∀｀)┌
-                    if ((byte)reader.PeekChar() >= 0x80)
+                    string stxName = wrdName.Replace(".wrd", ".stx");
+                    byte[] spcData = File.ReadAllBytes(textSPCName);
+                    SPC textSPC = new SPC(spcData, textSPCName);
+                    foreach (SPCEntry entry in textSPC.Entries)
                     {
-                        stringLen = reader.ReadInt16();
-                    }
-                    else
-                    {
-                        stringLen = reader.ReadByte();
-                    }
-                    stringLen += 2; // Null terminator
-
-                    List<char> stringData = new List<char>(stringLen / 2);
-                    for (int j = 0; j < (stringLen / 2); ++j)
-                    {
-                        char c = Convert.ToChar(reader.ReadUInt16());
-                        stringData.Add(c);
-
-                        // We can't always trust stringLen apparently, so break if we've hit a null terminator.
-                        if (c == 0)
+                        if (entry.Filename == stxName)
+                        {
+                            Strings = (new STX(entry.Contents)).Strings;
                             break;
+                        }
                     }
+                }
+                else
+                {
+                    reader.BaseStream.Seek(stringsPointer, SeekOrigin.Begin);
+                    for (ushort i = 0; i < stringCount; ++i)
+                    {
+                        short stringLen = 0;
 
-                    string str = new string(stringData.ToArray());
-                    str = str.Replace("\r", "\\r");
-                    str = str.Replace("\n", "\\n");
-                    Strings.Add(str);
+                        // The string length is a signed byte, so if it's larger than 0x7F,
+                        // that means the length is actually stored in a signed short,
+                        // since we can't have a negative string length.
+                        // ┐(´∀｀)┌
+                        if ((byte)reader.PeekChar() >= 0x80)
+                        {
+                            stringLen = reader.ReadInt16();
+                        }
+                        else
+                        {
+                            stringLen = reader.ReadByte();
+                        }
+                        stringLen += 2; // Null terminator
+
+                        List<char> stringData = new List<char>(stringLen / 2);
+                        for (int j = 0; j < (stringLen / 2); ++j)
+                        {
+                            char c = Convert.ToChar(reader.ReadUInt16());
+                            stringData.Add(c);
+
+                            // We can't always trust stringLen apparently, so break if we've hit a null terminator.
+                            if (c == 0)
+                                break;
+                        }
+
+                        string str = new string(stringData.ToArray());
+                        str = str.Replace("\r", "\\r");
+                        str = str.Replace("\n", "\\n");
+                        Strings.Add(str);
+                    }
                 }
             }
         }

--- a/FlashbackLight/Formats/WRD.cs
+++ b/FlashbackLight/Formats/WRD.cs
@@ -116,14 +116,8 @@ namespace FlashbackLight.Formats
                     string stxName = wrdName.Replace(".wrd", ".stx");
                     byte[] spcData = File.ReadAllBytes(textSPCName);
                     SPC textSPC = new SPC(spcData, textSPCName);
-                    foreach (SPCEntry entry in textSPC.Entries)
-                    {
-                        if (entry.Filename == stxName)
-                        {
-                            Strings = (new STX(entry.Contents)).Strings;
-                            break;
-                        }
-                    }
+
+                    Strings = new STX(textSPC.Entries[stxName].Contents).Strings;
                 }
                 else
                 {

--- a/FlashbackLight/MainForm.Designer.cs
+++ b/FlashbackLight/MainForm.Designer.cs
@@ -34,47 +34,56 @@
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.wrdViewer = new System.Windows.Forms.GroupBox();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.cmdMoveDown = new System.Windows.Forms.Button();
+            this.cmdMoveUp = new System.Windows.Forms.Button();
+            this.cmdDelete = new System.Windows.Forms.Button();
+            this.cmdAdd = new System.Windows.Forms.Button();
             this.currentWRDCommandList = new System.Windows.Forms.ListBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
             this.argCountBox = new System.Windows.Forms.NumericUpDown();
             this.opcodeComboBox = new System.Windows.Forms.ComboBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.cmdAdd = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.cmdDelete = new System.Windows.Forms.Button();
-            this.cmdMoveUp = new System.Windows.Forms.Button();
-            this.cmdMoveDown = new System.Windows.Forms.Button();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
+            this.stxViewer = new System.Windows.Forms.GroupBox();
+            this.currentSTXStringList = new System.Windows.Forms.ListBox();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.button3 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
+            this.wrdViewer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.groupBox3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).BeginInit();
             this.splitContainer3.Panel1.SuspendLayout();
             this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.argCountBox)).BeginInit();
-            this.panel1.SuspendLayout();
+            this.stxViewer.SuspendLayout();
+            this.panel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // currentSPCEntryList
             // 
             this.currentSPCEntryList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.currentSPCEntryList.Font = new System.Drawing.Font("Noto Mono", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.currentSPCEntryList.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.currentSPCEntryList.FormattingEnabled = true;
-            this.currentSPCEntryList.ItemHeight = 15;
+            this.currentSPCEntryList.ItemHeight = 16;
             this.currentSPCEntryList.Location = new System.Drawing.Point(3, 16);
             this.currentSPCEntryList.Name = "currentSPCEntryList";
             this.currentSPCEntryList.Size = new System.Drawing.Size(200, 418);
@@ -120,7 +129,8 @@
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.groupBox2);
+            this.splitContainer1.Panel2.Controls.Add(this.stxViewer);
+            this.splitContainer1.Panel2.Controls.Add(this.wrdViewer);
             this.splitContainer1.Size = new System.Drawing.Size(684, 437);
             this.splitContainer1.SplitterDistance = 206;
             this.splitContainer1.TabIndex = 2;
@@ -134,18 +144,19 @@
             this.groupBox1.Size = new System.Drawing.Size(206, 437);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Script Browser";
+            this.groupBox1.Text = "SPC Browser";
             // 
-            // groupBox2
+            // wrdViewer
             // 
-            this.groupBox2.Controls.Add(this.splitContainer2);
-            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Location = new System.Drawing.Point(0, 0);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(474, 437);
-            this.groupBox2.TabIndex = 1;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Script Viewer";
+            this.wrdViewer.Controls.Add(this.splitContainer2);
+            this.wrdViewer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.wrdViewer.Location = new System.Drawing.Point(0, 0);
+            this.wrdViewer.Name = "wrdViewer";
+            this.wrdViewer.Size = new System.Drawing.Size(474, 437);
+            this.wrdViewer.TabIndex = 1;
+            this.wrdViewer.TabStop = false;
+            this.wrdViewer.Text = "Script Viewer";
+            this.wrdViewer.Visible = false;
             // 
             // splitContainer2
             // 
@@ -164,20 +175,73 @@
             // 
             this.splitContainer2.Panel2.Controls.Add(this.groupBox3);
             this.splitContainer2.Size = new System.Drawing.Size(468, 418);
-            this.splitContainer2.SplitterDistance = 252;
+            this.splitContainer2.SplitterDistance = 251;
             this.splitContainer2.TabIndex = 0;
+            // 
+            // panel1
+            // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panel1.Controls.Add(this.cmdMoveDown);
+            this.panel1.Controls.Add(this.cmdMoveUp);
+            this.panel1.Controls.Add(this.cmdDelete);
+            this.panel1.Controls.Add(this.cmdAdd);
+            this.panel1.Location = new System.Drawing.Point(436, 3);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(32, 248);
+            this.panel1.TabIndex = 2;
+            // 
+            // cmdMoveDown
+            // 
+            this.cmdMoveDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmdMoveDown.Location = new System.Drawing.Point(3, 218);
+            this.cmdMoveDown.Name = "cmdMoveDown";
+            this.cmdMoveDown.Size = new System.Drawing.Size(26, 26);
+            this.cmdMoveDown.TabIndex = 4;
+            this.cmdMoveDown.Text = "↓";
+            this.cmdMoveDown.UseVisualStyleBackColor = true;
+            // 
+            // cmdMoveUp
+            // 
+            this.cmdMoveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmdMoveUp.Location = new System.Drawing.Point(3, 146);
+            this.cmdMoveUp.Name = "cmdMoveUp";
+            this.cmdMoveUp.Size = new System.Drawing.Size(26, 26);
+            this.cmdMoveUp.TabIndex = 3;
+            this.cmdMoveUp.Text = "↑";
+            this.cmdMoveUp.UseVisualStyleBackColor = true;
+            // 
+            // cmdDelete
+            // 
+            this.cmdDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmdDelete.Location = new System.Drawing.Point(3, 75);
+            this.cmdDelete.Name = "cmdDelete";
+            this.cmdDelete.Size = new System.Drawing.Size(26, 26);
+            this.cmdDelete.TabIndex = 2;
+            this.cmdDelete.Text = "-";
+            this.cmdDelete.UseVisualStyleBackColor = true;
+            // 
+            // cmdAdd
+            // 
+            this.cmdAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmdAdd.Location = new System.Drawing.Point(3, 3);
+            this.cmdAdd.Name = "cmdAdd";
+            this.cmdAdd.Size = new System.Drawing.Size(26, 26);
+            this.cmdAdd.TabIndex = 1;
+            this.cmdAdd.Text = "+";
+            this.cmdAdd.UseVisualStyleBackColor = true;
             // 
             // currentWRDCommandList
             // 
             this.currentWRDCommandList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.currentWRDCommandList.Font = new System.Drawing.Font("Noto Mono", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.currentWRDCommandList.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.currentWRDCommandList.FormattingEnabled = true;
-            this.currentWRDCommandList.ItemHeight = 15;
+            this.currentWRDCommandList.ItemHeight = 16;
             this.currentWRDCommandList.Location = new System.Drawing.Point(0, 0);
             this.currentWRDCommandList.Name = "currentWRDCommandList";
-            this.currentWRDCommandList.Size = new System.Drawing.Size(430, 252);
+            this.currentWRDCommandList.Size = new System.Drawing.Size(430, 228);
             this.currentWRDCommandList.TabIndex = 0;
             // 
             // groupBox3
@@ -186,7 +250,7 @@
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox3.Location = new System.Drawing.Point(0, 0);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(468, 162);
+            this.groupBox3.Size = new System.Drawing.Size(468, 163);
             this.groupBox3.TabIndex = 0;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Command Editor";
@@ -210,9 +274,28 @@
             // splitContainer3.Panel2
             // 
             this.splitContainer3.Panel2.Controls.Add(this.groupBox4);
-            this.splitContainer3.Size = new System.Drawing.Size(462, 143);
+            this.splitContainer3.Size = new System.Drawing.Size(462, 144);
             this.splitContainer3.SplitterDistance = 26;
             this.splitContainer3.TabIndex = 0;
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(290, 5);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(86, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Argument Count:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 5);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(48, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Opcode:";
             // 
             // argCountBox
             // 
@@ -236,82 +319,86 @@
             this.groupBox4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox4.Location = new System.Drawing.Point(0, 0);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(462, 113);
+            this.groupBox4.Size = new System.Drawing.Size(462, 114);
             this.groupBox4.TabIndex = 0;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Arguments";
             // 
-            // cmdAdd
+            // stxViewer
             // 
-            this.cmdAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cmdAdd.Location = new System.Drawing.Point(3, 3);
-            this.cmdAdd.Name = "cmdAdd";
-            this.cmdAdd.Size = new System.Drawing.Size(26, 26);
-            this.cmdAdd.TabIndex = 1;
-            this.cmdAdd.Text = "+";
-            this.cmdAdd.UseVisualStyleBackColor = true;
+            this.stxViewer.Controls.Add(this.currentSTXStringList);
+            this.stxViewer.Controls.Add(this.panel2);
+            this.stxViewer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.stxViewer.Location = new System.Drawing.Point(0, 0);
+            this.stxViewer.Name = "stxViewer";
+            this.stxViewer.Size = new System.Drawing.Size(474, 437);
+            this.stxViewer.TabIndex = 2;
+            this.stxViewer.TabStop = false;
+            this.stxViewer.Text = "String Viewer";
+            this.stxViewer.Visible = false;
             // 
-            // panel1
+            // currentSTXStringList
             // 
-            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.currentSTXStringList.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.currentSTXStringList.FormattingEnabled = true;
+            this.currentSTXStringList.ItemHeight = 16;
+            this.currentSTXStringList.Location = new System.Drawing.Point(6, 16);
+            this.currentSTXStringList.Name = "currentSTXStringList";
+            this.currentSTXStringList.Size = new System.Drawing.Size(430, 404);
+            this.currentSTXStringList.TabIndex = 0;
+            // 
+            // panel2
+            // 
+            this.panel2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.panel1.Controls.Add(this.cmdMoveDown);
-            this.panel1.Controls.Add(this.cmdMoveUp);
-            this.panel1.Controls.Add(this.cmdDelete);
-            this.panel1.Controls.Add(this.cmdAdd);
-            this.panel1.Location = new System.Drawing.Point(436, 3);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(32, 249);
-            this.panel1.TabIndex = 2;
+            this.panel2.Controls.Add(this.button1);
+            this.panel2.Controls.Add(this.button2);
+            this.panel2.Controls.Add(this.button3);
+            this.panel2.Controls.Add(this.button4);
+            this.panel2.Location = new System.Drawing.Point(439, 16);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(32, 418);
+            this.panel2.TabIndex = 2;
             // 
-            // cmdDelete
+            // button1
             // 
-            this.cmdDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.cmdDelete.Location = new System.Drawing.Point(3, 75);
-            this.cmdDelete.Name = "cmdDelete";
-            this.cmdDelete.Size = new System.Drawing.Size(26, 26);
-            this.cmdDelete.TabIndex = 2;
-            this.cmdDelete.Text = "-";
-            this.cmdDelete.UseVisualStyleBackColor = true;
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Location = new System.Drawing.Point(3, 388);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(26, 26);
+            this.button1.TabIndex = 4;
+            this.button1.Text = "↓";
+            this.button1.UseVisualStyleBackColor = true;
             // 
-            // cmdMoveUp
+            // button2
             // 
-            this.cmdMoveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.cmdMoveUp.Location = new System.Drawing.Point(3, 147);
-            this.cmdMoveUp.Name = "cmdMoveUp";
-            this.cmdMoveUp.Size = new System.Drawing.Size(26, 26);
-            this.cmdMoveUp.TabIndex = 3;
-            this.cmdMoveUp.Text = "↑";
-            this.cmdMoveUp.UseVisualStyleBackColor = true;
+            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button2.Location = new System.Drawing.Point(3, 316);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(26, 26);
+            this.button2.TabIndex = 3;
+            this.button2.Text = "↑";
+            this.button2.UseVisualStyleBackColor = true;
             // 
-            // cmdMoveDown
+            // button3
             // 
-            this.cmdMoveDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.cmdMoveDown.Location = new System.Drawing.Point(3, 219);
-            this.cmdMoveDown.Name = "cmdMoveDown";
-            this.cmdMoveDown.Size = new System.Drawing.Size(26, 26);
-            this.cmdMoveDown.TabIndex = 4;
-            this.cmdMoveDown.Text = "↓";
-            this.cmdMoveDown.UseVisualStyleBackColor = true;
+            this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button3.Location = new System.Drawing.Point(3, 75);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(26, 26);
+            this.button3.TabIndex = 2;
+            this.button3.Text = "-";
+            this.button3.UseVisualStyleBackColor = true;
             // 
-            // label1
+            // button4
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 5);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(48, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Opcode:";
-            // 
-            // label2
-            // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(290, 5);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(86, 13);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Argument Count:";
+            this.button4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button4.Location = new System.Drawing.Point(3, 3);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(26, 26);
+            this.button4.TabIndex = 1;
+            this.button4.Text = "+";
+            this.button4.UseVisualStyleBackColor = true;
             // 
             // MainForm
             // 
@@ -331,11 +418,12 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
-            this.groupBox2.ResumeLayout(false);
+            this.wrdViewer.ResumeLayout(false);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
             this.groupBox3.ResumeLayout(false);
             this.splitContainer3.Panel1.ResumeLayout(false);
             this.splitContainer3.Panel1.PerformLayout();
@@ -343,7 +431,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
             this.splitContainer3.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.argCountBox)).EndInit();
-            this.panel1.ResumeLayout(false);
+            this.stxViewer.ResumeLayout(false);
+            this.panel2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -359,7 +448,7 @@
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.ListBox currentWRDCommandList;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.GroupBox wrdViewer;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.SplitContainer splitContainer3;
         private System.Windows.Forms.ComboBox opcodeComboBox;
@@ -372,6 +461,13 @@
         private System.Windows.Forms.Button cmdDelete;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.GroupBox stxViewer;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button button4;
+        private System.Windows.Forms.ListBox currentSTXStringList;
     }
 }
 

--- a/FlashbackLight/MainForm.cs
+++ b/FlashbackLight/MainForm.cs
@@ -145,7 +145,7 @@ namespace FlashbackLight
             
             if (Path.GetExtension(filepath).ToLower() != ".spc")
             {
-                if (MessageBox.Show("Selected file does not have the .SPC file extension. Attempt to open anyways?",
+                if (MessageBox.Show("Selected file does not have the .SPC file extension and may not load properly. Attempt to open anyways?",
                                     "SPC Extension Warning",
                                     MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) != DialogResult.Yes)
                 {


### PR DESCRIPTION
See the individual commits for full details. The big things are:
1. Added STX viewer
2. Changed `SPC.Entries` from `List<SPCEntry>` to `Dictionary<string, SPCEntry>` (the string is for O(1) filename lookups)
3. Added error messages to avoid crashes
4. Rearranged some stuff in `MainForm.cs` for future modularity

I am open to feedback on anything that should be changed in this PR, as well as requests to help implement other stuff into Flashback Light.

Possible design changes that I didn't implement:
* Change `V3Format` from an abstract class into an interface `IV3Format`
* Make method names use UpperCamelCase to comply with C# style conventions